### PR TITLE
Add link to developer/GH info in Admin dropdown

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,4 @@ build/
 
 ### Local Configuration ###
 .env
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -51,4 +51,3 @@ build/
 
 ### Local Configuration ###
 .env
-.DS_Store

--- a/frontend/src/main/components/Nav/AppNavbar.js
+++ b/frontend/src/main/components/Nav/AppNavbar.js
@@ -153,6 +153,12 @@ export default function AppNavbar({
                   >
                     Manage Jobs
                   </NavDropdown.Item>
+                  <NavDropdown.Item
+                    href="/developer"
+                    data-testid="appnavbar-developer-info"
+                  >
+                    Developer Info
+                  </NavDropdown.Item>
                 </NavDropdown>
               )}
             </Nav>

--- a/frontend/src/tests/components/Nav/AppNavbar.test.js
+++ b/frontend/src/tests/components/Nav/AppNavbar.test.js
@@ -58,9 +58,7 @@ describe("AppNavbar tests", () => {
     expect(
       screen.getByTestId(/appnavbar-admin-personalschedule/),
     ).toBeInTheDocument();
-    expect(
-      screen.getByTestId(/appnavbar-developer-info/),
-    ).toBeInTheDocument();
+    expect(screen.getByTestId(/appnavbar-developer-info/)).toBeInTheDocument();
   });
 
   test("renders H2Console and Swagger links correctly", async () => {

--- a/frontend/src/tests/components/Nav/AppNavbar.test.js
+++ b/frontend/src/tests/components/Nav/AppNavbar.test.js
@@ -58,6 +58,9 @@ describe("AppNavbar tests", () => {
     expect(
       screen.getByTestId(/appnavbar-admin-personalschedule/),
     ).toBeInTheDocument();
+    expect(
+      screen.getByTestId(/appnavbar-developer-info/),
+    ).toBeInTheDocument();
   });
 
   test("renders H2Console and Swagger links correctly", async () => {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -33,3 +33,5 @@ app.endQtrYYYYQ=${END_QTR:${env.END_QTR:20222}}
 
 app.ucsb.api.consumer_key=${UCSB_API_KEY:${env.UCSB_API_KEY:see-instructions-in-readme}}
 server.port=${PORT:8080}
+
+spring.data.mongodb.database=database


### PR DESCRIPTION
In this PR, we add an item in the Admin dropdown called "Developer Info", which would navigate us to `\developer`, the developer page.

Dokku deployment: https://proj-tantaiyanhen-dev.dokku-05.cs.ucsb.edu 

<img width="1201" alt="截屏2024-02-26 下午4 00 20" src="https://github.com/ucsb-cs156-w24/proj-courses-w24-5pm-1/assets/124806197/0d4296ce-377a-4e8f-b413-ed5eab1983ff">

Closes #2 
