### PR TITLE
UX: Remove unnecessary exclamation point

### DIFF
--- a/frontend/src/main/pages/CourseDetails/CourseDetailsIndexPage.js
+++ b/frontend/src/main/pages/CourseDetails/CourseDetailsIndexPage.js
@@ -30,7 +30,7 @@ export default function CourseDetailsIndexPage() {
       <div className="pt-2">
         {moreDetails && moreDetails.courseId && (
           <h5>
-            Course Details for {moreDetails.courseId} {yyyyqToQyy(qtr)}!
+            Course Details for {moreDetails.courseId} {yyyyqToQyy(qtr)}
           </h5>
         )}
 

--- a/frontend/src/tests/pages/CourseDetails/CourseDetailsIndexPage.test.js
+++ b/frontend/src/tests/pages/CourseDetails/CourseDetailsIndexPage.test.js
@@ -79,7 +79,7 @@ describe("Course Details Index Page tests", () => {
     );
     // await waitFor(() => {
     expect(
-      screen.getByText("Course Details for CHEM 184 W22!"),
+      screen.getByText("Course Details for CHEM 184 W22"),
     ).toBeInTheDocument();
     // });
     expect(screen.getByText("Enroll Code")).toBeInTheDocument();


### PR DESCRIPTION

Removed the exclamation point after the course title, so it says: 

```
Course Details for CMPSC 5A S22
```

Not

```
Course Details for CMPSC 5A S22!
```
FIXED VERSION:
<img width="497" alt="image" src="https://github.com/ucsb-cs156-w24/proj-courses-w24-5pm-1/assets/91820969/27f3fb3f-1013-4569-9382-8663befbd0a4">
closes #5 

OLD VERSION:
Start on the main page, and look up a list of courses, e.g. CMPSC for S22, like this.

<img width="840" alt="image" src="https://github.com/ucsb-cs156/proj-courses/assets/37964098/687a24de-0dee-44be-9469-9aedc5f920d1">

Then, click the info button beside a course, like this (see the i in a circle at the right hand edge of the line for CMPSC 5A, and click it).

<img width="1342" alt="image" src="https://github.com/ucsb-cs156/proj-courses/assets/37964098/32f2e237-bfb2-41a1-acb3-0aaa1986d843">